### PR TITLE
Add configurable mod rotation mappings

### DIFF
--- a/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -47,6 +47,7 @@ import com.sk89q.worldedit.forge.compat.CarpentersBlocksBlockTransformHook;
 import com.sk89q.worldedit.forge.compat.ForgeMultipartCompat;
 import com.sk89q.worldedit.forge.compat.ForgeMultipartExistsCompat;
 import com.sk89q.worldedit.forge.compat.ModRotationBlockTransformHook;
+import com.sk89q.worldedit.forge.compat.ModRotationConfig;
 import com.sk89q.worldedit.forge.compat.NoForgeMultipartCompat;
 import com.sk89q.worldedit.internal.LocalWorldAdapter;
 
@@ -104,6 +105,8 @@ public class ForgeWorldEdit {
 
         config = new ForgeConfiguration(this);
         config.load();
+
+        ModRotationConfig.init(workingDir);
 
         if (Loader.isModLoaded("ForgeMultipart")) {
             compat = new ForgeMultipartExistsCompat();

--- a/src/main/java/com/sk89q/worldedit/forge/compat/ModRotationBlockTransformHook.java
+++ b/src/main/java/com/sk89q/worldedit/forge/compat/ModRotationBlockTransformHook.java
@@ -5,9 +5,15 @@ import java.util.Map;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockDoor;
+import net.minecraft.block.BlockFenceGate;
 import net.minecraft.block.BlockRotatedPillar;
 import net.minecraft.block.BlockStairs;
 import net.minecraft.block.BlockTrapDoor;
+
+import com.sk89q.worldedit.forge.compat.RotationType;
+import com.sk89q.worldedit.forge.compat.ModRotationConfig;
+import com.sk89q.worldedit.forge.compat.RotationMapping;
+import com.sk89q.worldedit.forge.compat.RotationUtils;
 
 import com.sk89q.worldedit.Vector;
 import com.sk89q.worldedit.blocks.BaseBlock;
@@ -20,34 +26,19 @@ import com.sk89q.worldedit.math.transform.Transform;
  */
 public class ModRotationBlockTransformHook implements BlockTransformHook {
 
-    private enum Type {
-        STAIRS,
-        PILLAR,
-        DOOR,
-        TRAP_DOOR
-    }
+    private final Map<Integer, RotationMapping> cache = new HashMap<>();
 
-    private final Map<Integer, Type> cache = new HashMap<>();
-
-    private Type lookup(int id) {
+    private RotationMapping lookup(int id) {
         if (cache.containsKey(id)) {
             return cache.get(id);
         }
         Block mcBlock = Block.getBlockById(id);
-        Type result = null;
+        RotationMapping result = null;
         if (mcBlock != null) {
             Object identifier = Block.blockRegistry.getNameForObject(mcBlock);
             String name = identifier == null ? null : identifier.toString();
-            if (name != null && !name.startsWith("minecraft:")) {
-                if (mcBlock instanceof BlockStairs) {
-                    result = Type.STAIRS;
-                } else if (mcBlock instanceof BlockRotatedPillar) {
-                    result = Type.PILLAR;
-                } else if (mcBlock instanceof BlockDoor) {
-                    result = Type.DOOR;
-                } else if (mcBlock instanceof BlockTrapDoor) {
-                    result = Type.TRAP_DOOR;
-                }
+            if (name != null) {
+                result = ModRotationConfig.getInstance().get(name);
             }
         }
         cache.put(id, result);
@@ -59,8 +50,8 @@ public class ModRotationBlockTransformHook implements BlockTransformHook {
         if (!(transform instanceof AffineTransform affine)) {
             return block;
         }
-        Type type = lookup(block.getId());
-        if (type == null) {
+        RotationMapping mapping = lookup(block.getId());
+        if (mapping == null) {
             return block;
         }
         Vector rot = affine.getRotations();
@@ -71,18 +62,28 @@ public class ModRotationBlockTransformHook implements BlockTransformHook {
         int data = block.getData();
         int steps = Math.abs(ticks) % 4;
         for (int i = 0; i < steps; i++) {
-            switch (type) {
+            if (mapping.getMetas() != null && !mapping.getMetas().isEmpty()) {
+                data = rotateCustom(data, mapping.getMetas(), ticks > 0);
+                continue;
+            }
+            switch (mapping.getType()) {
                 case STAIRS:
-                    data = ticks > 0 ? rotateStairs90(data) : rotateStairs90Reverse(data);
+                    data = ticks > 0 ? RotationUtils.rotateStairs90(data) : RotationUtils.rotateStairs90Reverse(data);
                     break;
                 case PILLAR:
-                    data = rotatePillar90(data); // same both directions
+                    data = RotationUtils.rotatePillar90(data); // same both directions
                     break;
                 case DOOR:
-                    data = ticks > 0 ? rotateDoor90(data) : rotateDoor90Reverse(data);
+                    data = ticks > 0 ? RotationUtils.rotateDoor90(data) : RotationUtils.rotateDoor90Reverse(data);
                     break;
                 case TRAP_DOOR:
-                    data = ticks > 0 ? rotateTrapdoor90(data) : rotateTrapdoor90Reverse(data);
+                    data = ticks > 0 ? RotationUtils.rotateTrapdoor90(data) : RotationUtils.rotateTrapdoor90Reverse(data);
+                    break;
+                case FENCE_GATE:
+                    data = ticks > 0 ? RotationUtils.rotateFenceGate90(data) : RotationUtils.rotateFenceGate90Reverse(data);
+                    break;
+                case OTHER:
+                    // no meta mapping provided
                     break;
             }
         }
@@ -90,148 +91,39 @@ public class ModRotationBlockTransformHook implements BlockTransformHook {
         return block;
     }
 
-    private int rotatePillar90(int data) {
-        if (data >= 4 && data <= 11) {
-            return data ^ 0xC;
-        }
-        return data;
-    }
 
-    private int rotateStairs90(int data) {
-        boolean bigMeta = data >= 8;
-        int meta = bigMeta ? data - 8 : data;
-        int result;
-        switch (meta) {
-            case 0:
-                result = 2;
-                break;
-            case 1:
-                result = 3;
-                break;
-            case 2:
-                result = 1;
-                break;
-            case 3:
-                result = 0;
-                break;
-            case 4:
-                result = 6;
-                break;
-            case 5:
-                result = 7;
-                break;
-            case 6:
-                result = 5;
-                break;
-            case 7:
-                result = 4;
-                break;
-            default:
-                result = meta;
+    private int rotateCustom(int data, Map<String, Integer> map, boolean clockwise) {
+        if (map == null || map.isEmpty()) {
+            return data;
         }
-        return bigMeta ? result + 8 : result;
-    }
-
-    private int rotateStairs90Reverse(int data) {
-        boolean bigMeta = data >= 8;
-        int meta = bigMeta ? data - 8 : data;
-        int result;
-        switch (meta) {
-            case 2:
-                result = 0;
-                break;
-            case 3:
-                result = 1;
-                break;
-            case 1:
-                result = 2;
-                break;
-            case 0:
-                result = 3;
-                break;
-            case 6:
-                result = 4;
-                break;
-            case 7:
-                result = 5;
-                break;
-            case 5:
-                result = 6;
-                break;
-            case 4:
-                result = 7;
-                break;
-            default:
-                result = meta;
-        }
-        return bigMeta ? result + 8 : result;
-    }
-
-    private int rotateDoor90(int data) {
         int extra = data & ~0x3;
-        int without = data & 0x3;
-        switch (without) {
-            case 0:
-                return 1 | extra;
-            case 1:
-                return 2 | extra;
-            case 2:
-                return 3 | extra;
-            case 3:
-                return 0 | extra;
-            default:
-                return data;
-        }
-    }
-
-    private int rotateDoor90Reverse(int data) {
-        int extra = data & ~0x3;
-        int without = data & 0x3;
-        switch (without) {
-            case 1:
-                return 0 | extra;
-            case 2:
-                return 1 | extra;
-            case 3:
-                return 2 | extra;
-            case 0:
-                return 3 | extra;
-            default:
-                return data;
-        }
-    }
-
-    private int rotateTrapdoor90(int data) {
-        int without = data & ~0x3;
         int orientation = data & 0x3;
-        switch (orientation) {
-            case 0:
-                return 3 | without;
-            case 1:
-                return 2 | without;
-            case 2:
-                return 0 | without;
-            case 3:
-                return 1 | without;
-            default:
-                return data;
+        String dir = null;
+        for (Map.Entry<String, Integer> e : map.entrySet()) {
+            if (e.getValue() == orientation) {
+                dir = e.getKey().toLowerCase();
+                break;
+            }
         }
-    }
-
-    private int rotateTrapdoor90Reverse(int data) {
-        int without = data & ~0x3;
-        int orientation = data & 0x3;
-        switch (orientation) {
-            case 3:
-                return 0 | without;
-            case 2:
-                return 1 | without;
-            case 0:
-                return 2 | without;
-            case 1:
-                return 3 | without;
-            default:
-                return data;
+        if (dir == null) {
+            return data;
         }
+        String[] order = {"north", "east", "south", "west"};
+        int idx = -1;
+        for (int i = 0; i < order.length; i++) {
+            if (order[i].equals(dir)) {
+                idx = i;
+                break;
+            }
+        }
+        if (idx == -1) {
+            return data;
+        }
+        int newIdx = clockwise ? (idx + 1) & 3 : (idx + 3) & 3;
+        Integer newMeta = map.get(order[newIdx]);
+        if (newMeta == null) {
+            return data;
+        }
+        return extra | newMeta;
     }
 }

--- a/src/main/java/com/sk89q/worldedit/forge/compat/ModRotationConfig.java
+++ b/src/main/java/com/sk89q/worldedit/forge/compat/ModRotationConfig.java
@@ -1,0 +1,102 @@
+package com.sk89q.worldedit.forge.compat;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.sk89q.worldedit.util.gson.GsonUtil;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockDoor;
+import net.minecraft.block.BlockFenceGate;
+import net.minecraft.block.BlockRotatedPillar;
+import net.minecraft.block.BlockStairs;
+import net.minecraft.block.BlockTrapDoor;
+
+import com.sk89q.worldedit.forge.compat.RotationUtils;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Loads and stores rotation mappings for modded blocks.
+ */
+public class ModRotationConfig {
+
+    private static ModRotationConfig instance;
+
+    private final File file;
+    private final Gson gson = GsonUtil.createBuilder().setPrettyPrinting().create();
+    private Map<String, RotationMapping> mappings = new HashMap<>();
+
+    private ModRotationConfig(File file) {
+        this.file = file;
+        load();
+    }
+
+    public static void init(File dir) {
+        instance = new ModRotationConfig(new File(dir, "mod-rotations.json"));
+    }
+
+    public static ModRotationConfig getInstance() {
+        return instance;
+    }
+
+    public RotationMapping get(String name) {
+        return mappings.get(name);
+    }
+
+    private void load() {
+        if (!file.exists()) {
+            generateDefaults();
+            save();
+            return;
+        }
+        Type type = new TypeToken<Map<String, RotationMapping>>(){}.getType();
+        try (FileReader reader = new FileReader(file)) {
+            Map<String, RotationMapping> raw = gson.fromJson(reader, type);
+            if (raw != null) {
+                mappings.putAll(raw);
+            }
+        } catch (IOException ignored) {
+        }
+    }
+
+    private void save() {
+        Map<String, RotationMapping> raw = new HashMap<>(mappings);
+        try (FileWriter writer = new FileWriter(file)) {
+            gson.toJson(raw, writer);
+        } catch (IOException ignored) {
+        }
+    }
+
+    private void generateDefaults() {
+        Iterator<?> it = Block.blockRegistry.iterator();
+        while (it.hasNext()) {
+            Block block = (Block) it.next();
+            Object identifier = Block.blockRegistry.getNameForObject(block);
+            String name = identifier == null ? null : identifier.toString();
+            if (name == null) continue;
+            RotationType type = null;
+            if (block instanceof BlockStairs) {
+                type = RotationType.STAIRS;
+            } else if (block instanceof BlockRotatedPillar) {
+                type = RotationType.PILLAR;
+            } else if (block instanceof BlockDoor) {
+                type = RotationType.DOOR;
+            } else if (block instanceof BlockTrapDoor) {
+                type = RotationType.TRAP_DOOR;
+            } else if (block instanceof BlockFenceGate) {
+                type = RotationType.FENCE_GATE;
+            }
+            if (type != null) {
+                RotationMapping mapping = new RotationMapping(type);
+                mapping.setMetas(RotationUtils.defaultMetaMap(type));
+                mappings.put(name, mapping);
+            }
+        }
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/forge/compat/RotationMapping.java
+++ b/src/main/java/com/sk89q/worldedit/forge/compat/RotationMapping.java
@@ -1,0 +1,36 @@
+package com.sk89q.worldedit.forge.compat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Mapping information for rotating a block.
+ */
+public class RotationMapping {
+
+    private RotationType type = RotationType.OTHER;
+    private Map<String, Integer> metas = new HashMap<>();
+
+    public RotationMapping() {
+    }
+
+    public RotationMapping(RotationType type) {
+        this.type = type;
+    }
+
+    public RotationType getType() {
+        return type;
+    }
+
+    public void setType(RotationType type) {
+        this.type = type;
+    }
+
+    public Map<String, Integer> getMetas() {
+        return metas;
+    }
+
+    public void setMetas(Map<String, Integer> metas) {
+        this.metas = metas;
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/forge/compat/RotationType.java
+++ b/src/main/java/com/sk89q/worldedit/forge/compat/RotationType.java
@@ -1,0 +1,13 @@
+package com.sk89q.worldedit.forge.compat;
+
+/**
+ * Types of rotation mappings for modded blocks.
+ */
+public enum RotationType {
+    STAIRS,
+    PILLAR,
+    DOOR,
+    TRAP_DOOR,
+    FENCE_GATE,
+    OTHER
+}

--- a/src/main/java/com/sk89q/worldedit/forge/compat/RotationUtils.java
+++ b/src/main/java/com/sk89q/worldedit/forge/compat/RotationUtils.java
@@ -1,0 +1,204 @@
+package com.sk89q.worldedit.forge.compat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.IntUnaryOperator;
+
+/** Utility methods for rotation mappings. */
+public final class RotationUtils {
+    private RotationUtils() {}
+
+    public static int rotatePillar90(int data) {
+        if (data >= 4 && data <= 11) {
+            return data ^ 0xC;
+        }
+        return data;
+    }
+
+    public static int rotateStairs90(int data) {
+        boolean bigMeta = data >= 8;
+        int meta = bigMeta ? data - 8 : data;
+        int result;
+        switch (meta) {
+            case 0:
+                result = 2;
+                break;
+            case 1:
+                result = 3;
+                break;
+            case 2:
+                result = 1;
+                break;
+            case 3:
+                result = 0;
+                break;
+            case 4:
+                result = 6;
+                break;
+            case 5:
+                result = 7;
+                break;
+            case 6:
+                result = 5;
+                break;
+            case 7:
+                result = 4;
+                break;
+            default:
+                result = meta;
+        }
+        return bigMeta ? result + 8 : result;
+    }
+
+    public static int rotateStairs90Reverse(int data) {
+        boolean bigMeta = data >= 8;
+        int meta = bigMeta ? data - 8 : data;
+        int result;
+        switch (meta) {
+            case 2:
+                result = 0;
+                break;
+            case 3:
+                result = 1;
+                break;
+            case 1:
+                result = 2;
+                break;
+            case 0:
+                result = 3;
+                break;
+            case 6:
+                result = 4;
+                break;
+            case 7:
+                result = 5;
+                break;
+            case 5:
+                result = 6;
+                break;
+            case 4:
+                result = 7;
+                break;
+            default:
+                result = meta;
+        }
+        return bigMeta ? result + 8 : result;
+    }
+
+    public static int rotateDoor90(int data) {
+        int extra = data & ~0x3;
+        int without = data & 0x3;
+        switch (without) {
+            case 0:
+                return 1 | extra;
+            case 1:
+                return 2 | extra;
+            case 2:
+                return 3 | extra;
+            case 3:
+                return 0 | extra;
+            default:
+                return data;
+        }
+    }
+
+    public static int rotateDoor90Reverse(int data) {
+        int extra = data & ~0x3;
+        int without = data & 0x3;
+        switch (without) {
+            case 1:
+                return 0 | extra;
+            case 2:
+                return 1 | extra;
+            case 3:
+                return 2 | extra;
+            case 0:
+                return 3 | extra;
+            default:
+                return data;
+        }
+    }
+
+    public static int rotateTrapdoor90(int data) {
+        int without = data & ~0x3;
+        int orientation = data & 0x3;
+        switch (orientation) {
+            case 0:
+                return 3 | without;
+            case 1:
+                return 2 | without;
+            case 2:
+                return 0 | without;
+            case 3:
+                return 1 | without;
+            default:
+                return data;
+        }
+    }
+
+    public static int rotateTrapdoor90Reverse(int data) {
+        int without = data & ~0x3;
+        int orientation = data & 0x3;
+        switch (orientation) {
+            case 3:
+                return 0 | without;
+            case 2:
+                return 1 | without;
+            case 0:
+                return 2 | without;
+            case 1:
+                return 3 | without;
+            default:
+                return data;
+        }
+    }
+
+    public static int rotateFenceGate90(int data) {
+        int extra = data & ~0x3;
+        int orientation = data & 0x3;
+        orientation = (orientation + 1) & 3;
+        return orientation | extra;
+    }
+
+    public static int rotateFenceGate90Reverse(int data) {
+        int extra = data & ~0x3;
+        int orientation = data & 0x3;
+        orientation = (orientation + 3) & 3;
+        return orientation | extra;
+    }
+
+    public static Map<String,Integer> defaultMetaMap(RotationType type) {
+        Map<String,Integer> map = new LinkedHashMap<>();
+        switch (type) {
+            case STAIRS:
+                fillDirectional(map, 0, RotationUtils::rotateStairs90);
+                break;
+            case DOOR:
+                fillDirectional(map, 0, RotationUtils::rotateDoor90);
+                break;
+            case TRAP_DOOR:
+                fillDirectional(map, 0, RotationUtils::rotateTrapdoor90);
+                break;
+            case FENCE_GATE:
+                fillDirectional(map, 0, RotationUtils::rotateFenceGate90);
+                break;
+            case PILLAR:
+                map.put("y", 0);
+                map.put("x", 4);
+                map.put("z", 8);
+                break;
+            default:
+                break;
+        }
+        return map;
+    }
+
+    private static void fillDirectional(Map<String,Integer> map, int start, IntUnaryOperator rot) {
+        String[] dirs = {"north","east","south","west"};
+        int meta = start;
+        for (String dir : dirs) {
+            map.put(dir, meta);
+            meta = rot.applyAsInt(meta);
+        }
+    }
+}

--- a/src/test/java/com/sk89q/worldedit/forge/compat/ModRotationConfigTest.java
+++ b/src/test/java/com/sk89q/worldedit/forge/compat/ModRotationConfigTest.java
@@ -1,0 +1,24 @@
+package com.sk89q.worldedit.forge.compat;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.nio.file.Files;
+
+import org.junit.Test;
+
+/** Tests for {@link ModRotationConfig}. */
+public class ModRotationConfigTest {
+
+    @Test
+    public void testGenerateDefaults() throws Exception {
+        File dir = Files.createTempDirectory("modrot").toFile();
+        System.out.println("DIR=" + dir.getAbsolutePath());
+        ModRotationConfig.init(dir);
+        ModRotationConfig cfg = ModRotationConfig.getInstance();
+        assertNotNull(cfg);
+        File f = new File(dir, "mod-rotations.json");
+        assertTrue("config file missing", f.exists());
+        assertTrue(f.exists());
+    }
+}


### PR DESCRIPTION
## Summary
- centralize rotation helpers in new `RotationUtils`
- auto-generate default meta mappings for all blocks in `ModRotationConfig`
- allow custom mappings for any block in `ModRotationBlockTransformHook`
- basic test ensures config file generation

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687942a38da883238c2bc739e65281d0