### PR TITLE
Remove local AWE jars; fetch via JitPack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ src/main/resources/mixins.*([!.]).json
 !gradlew.bat
 .factorypath
 layout.json
+asyncworldedit/libs/

--- a/README.md
+++ b/README.md
@@ -2,3 +2,26 @@
 
 [WorldEdit](https://github.com/EngineHub/WorldEdit/tree/forge-archive/1.7.10) fork at 1.7.10 for use in a GTNH instance. Non-forge
 related code has been removed for ease of maintenance.
+Patch AsyncWorldEdit
+--------------------
+This repository includes `asyncworldedit_patch.diff`, which modifies
+AsyncWorldEdit v3.5.4 so it can run with this fork of WorldEdit.
+To build AsyncWorldEdit:
+
+1. Clone `https://github.com/SBPrime/AsyncWorldEdit` and checkout tag `v3.5.4`.
+2. Apply `asyncworldedit_patch.diff` from this repo:
+   ```bash
+   git apply ../worldedit-gtnh/asyncworldedit_patch.diff
+   ```
+3. Add JitPack as a repository and depend on the prebuilt
+   `worldedit-bukkit` and `fml` artifacts. Example for Gradle:
+   ```groovy
+   repositories { maven { url 'https://jitpack.io' } }
+   dependencies {
+       compileOnly 'com.github.GTNewHorizons:WorldEdit-GTNH:HEAD-SNAPSHOT:all'
+       implementation 'com.github.GTNewHorizons:Forge:1.7.10-142.1104'
+   }
+   ```
+4. Run `./gradlew build` to produce the Bukkit plugin and Forge injector jars.
+
+The required jars are hosted on JitPack so the `asyncworldedit/libs` folder is no longer used.

--- a/asyncworldedit_patch.diff
+++ b/asyncworldedit_patch.diff
@@ -1,0 +1,13 @@
+diff --git a/AsyncWorldEdit/src/main/java/org/primesoft/asyncworldedit/injector/scanner/ClassScanner.java b/AsyncWorldEdit/src/main/java/org/primesoft/asyncworldedit/injector/scanner/ClassScanner.java
+index e3b7a3d..2b9dc58 100644
+--- a/AsyncWorldEdit/src/main/java/org/primesoft/asyncworldedit/injector/scanner/ClassScanner.java
++++ b/AsyncWorldEdit/src/main/java/org/primesoft/asyncworldedit/injector/scanner/ClassScanner.java
+@@ -342,6 +342,8 @@ public abstract class ClassScanner implements IClassScanner {
+             new ClassScannerEntry(YAMLNode.class),
+             new ClassScannerEntry(Field.class),
+             new ClassScannerEntry(Method.class),
++            new ClassScannerEntry(org.objectweb.asm.tree.InsnList.class),
++            new ClassScannerEntry("codechicken.lib.asm.InsnListSection"),
+             new ClassScannerEntry("com.sk89q.wepif.PermissionsResolver"),
+             new ClassScannerEntry(Logger.class),
+             new ClassScannerEntry(Player.class),


### PR DESCRIPTION
## Summary
- drop `asyncworldedit/libs` prebuilt jars
- ignore future `asyncworldedit/libs` additions
- document how to patch and build AsyncWorldEdit with JitPack

## Testing
- `./gradlew jar --console=plain -q`
- `./gradlew test --console=plain -q`


------
https://chatgpt.com/codex/tasks/task_e_687feb97329c8323b805487122b703dc