### PR TITLE
Add rotation mapping reload command

### DIFF
--- a/src/main/java/com/sk89q/worldedit/extension/platform/CommandManager.java
+++ b/src/main/java/com/sk89q/worldedit/extension/platform/CommandManager.java
@@ -158,6 +158,7 @@ public final class CommandManager {
             .group("worldedit", "we")
             .describeAs("WorldEdit commands")
             .registerMethods(new WorldEditCommands(worldEdit))
+            .registerMethods(new com.sk89q.worldedit.forge.command.ForgeRotationCommands(worldEdit))
             .parent()
             .group("schematic", "schem", "/schematic", "/schem")
             .describeAs("Schematic commands for saving/loading areas")

--- a/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
+++ b/src/main/java/com/sk89q/worldedit/forge/ForgeWorldEdit.java
@@ -95,6 +95,7 @@ public class ForgeWorldEdit {
     private ForgeConfiguration config;
     private File workingDir;
     private ForgeMultipartCompat compat = new NoForgeMultipartCompat();
+    private ModRotationBlockTransformHook modRotationHook;
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
@@ -119,8 +120,9 @@ public class ForgeWorldEdit {
             ForgeWorldData.getInstance()
                 .addBlockTransformHook(new CarpentersBlocksBlockTransformHook());
         }
+        modRotationHook = new ModRotationBlockTransformHook();
         ForgeWorldData.getInstance()
-            .addBlockTransformHook(new ModRotationBlockTransformHook());
+            .addBlockTransformHook(modRotationHook);
 
         FMLCommonHandler.instance()
             .bus()
@@ -325,6 +327,13 @@ public class ForgeWorldEdit {
 
     public ForgeMultipartCompat getFMPCompat() {
         return compat;
+    }
+
+    /**
+     * Get the rotation hook used for mod block transformations.
+     */
+    public ModRotationBlockTransformHook getModRotationHook() {
+        return modRotationHook;
     }
 
     /**

--- a/src/main/java/com/sk89q/worldedit/forge/command/ForgeRotationCommands.java
+++ b/src/main/java/com/sk89q/worldedit/forge/command/ForgeRotationCommands.java
@@ -1,0 +1,35 @@
+package com.sk89q.worldedit.forge.command;
+
+import com.sk89q.minecraft.util.commands.Command;
+import com.sk89q.minecraft.util.commands.CommandContext;
+import com.sk89q.minecraft.util.commands.CommandPermissions;
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.WorldEditException;
+import com.sk89q.worldedit.extension.platform.Actor;
+import com.sk89q.worldedit.forge.ForgeWorldEdit;
+import com.sk89q.worldedit.forge.compat.ModRotationBlockTransformHook;
+import com.sk89q.worldedit.forge.compat.rotation.RotationMappings;
+
+/**
+ * Forge-specific commands.
+ */
+public class ForgeRotationCommands {
+
+    private final WorldEdit we;
+
+    public ForgeRotationCommands(WorldEdit we) {
+        this.we = we;
+    }
+
+    /** Reload rotation mappings from disk. */
+    @Command(aliases = { "reloadmappings" }, usage = "", desc = "Reload rotation mappings", min = 0, max = 0)
+    @CommandPermissions("worldedit.reload")
+    public void reloadMappings(Actor actor, CommandContext args) throws WorldEditException {
+        RotationMappings.init(ForgeWorldEdit.inst.getWorkingDir());
+        ModRotationBlockTransformHook hook = ForgeWorldEdit.inst.getModRotationHook();
+        if (hook != null) {
+            hook.clearCache();
+        }
+        actor.print("Rotation mappings reloaded!");
+    }
+}

--- a/src/main/java/com/sk89q/worldedit/forge/compat/ModRotationBlockTransformHook.java
+++ b/src/main/java/com/sk89q/worldedit/forge/compat/ModRotationBlockTransformHook.java
@@ -22,6 +22,11 @@ public class ModRotationBlockTransformHook implements BlockTransformHook {
 
     private final Map<Integer, RotationMapping> cache = new HashMap<>();
 
+    /** Clear the cached lookups. */
+    public void clearCache() {
+        cache.clear();
+    }
+
     private RotationMapping lookup(int id) {
         if (cache.containsKey(id)) {
             return cache.get(id);


### PR DESCRIPTION
## Summary
- add ForgeRotationCommands with `/reloadmappings`
- maintain reference to ModRotationBlockTransformHook and expose it
- clear ModRotationBlockTransformHook cache when reloading
- register ForgeRotationCommands with the command manager

## Testing
- `./gradlew build --no-daemon -x test` *(fails: cannot find Java toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_687f5219685c8323bd32b047ce7cb349