### PR TITLE
Fix AddBlocks2 reconstruction when reading schematics

### DIFF
--- a/docs/addblocks2-behavior.md
+++ b/docs/addblocks2-behavior.md
@@ -1,0 +1,9 @@
+# Schematic AddBlocks2 notes
+
+`AddBlocks2` is only written when a block in the clipboard has an ID above 4095.
+If a mod remaps its runtime IDs below that ceiling (e.g., showing `15122` in the
+UI but exposing `<=4095` to WorldEdit), the `AddBlocks2` array stays empty
+because `SchematicWriter` never sees a value over 4095 when iterating the
+clipboard blocks. The NEID transformer raises `BaseBlock.MAX_ID`, but WorldEdit
+still depends on the runtime IDs it receives from the world when deciding
+whether to populate `AddBlocks2`.

--- a/docs/chunker-schematic-converter-review.md
+++ b/docs/chunker-schematic-converter-review.md
@@ -1,0 +1,50 @@
+# Chunker SchematicConverter AddBlocks2 behavior review
+
+This note reviews the `SchematicConverter` from the ChunkPort branch `implement-schematic-conversion-system-te5vi7` and how it handles the NotEnoughIDs `AddBlocks2` extension in classic WorldEdit schematics.
+
+## Reading schematics
+
+* Classic schematics combine `Blocks` (low 8 bits) with optional `AddBlocks` (bits 8–11) and `AddBlocks2` (bits 12–15) nibble arrays. The converter reconstructs the runtime block ID by nibble-unpacking both arrays when present, so any upper bits saved in `AddBlocks2` are honored while loading.
+
+```java
+byte[] blocks = root.getByteArray("Blocks");
+byte[] addBlocks = root.contains("AddBlocks") ? root.getByteArray("AddBlocks") : null;
+byte[] addBlocks2 = root.contains("AddBlocks2") ? root.getByteArray("AddBlocks2") : null;
+...
+int id = blocks[index] & 0xFF;
+if (addBlocks != null && (index >> 1) < addBlocks.length) {
+    int add = (index & 1) == 0 ? addBlocks[index >> 1] & 0x0F : (addBlocks[index >> 1] & 0xF0) >> 4;
+    id |= add << 8;
+}
+if (addBlocks2 != null && (index >> 1) < addBlocks2.length) {
+    int add = (index & 1) == 0 ? addBlocks2[index >> 1] & 0x0F : (addBlocks2[index >> 1] & 0xF0) >> 4;
+    id |= add << 12;
+}
+```
+
+## Writing schematics
+
+* The converter always writes classic schematics and packs IDs >255 into `AddBlocks`.
+* IDs above 4095 are only preserved if the caller passes `allowNeids = true`, which allocates an `AddBlocks2` nibble array and stores the upper 4 bits (bits 12–15). With `allowNeids = false`, those high bits are dropped and IDs are truncated to 12 bits.
+* The nibble packing mirrors the read logic (half-byte per block, `(volume >> 1) + 1` length), so data that was originally saved with `AddBlocks2` will round-trip correctly when NEIDs is allowed.
+
+```java
+int id = schematic.getBlockIds()[i];
+blocks[i] = (byte) (id & 0xFF);
+if (id > 255) {
+    if (addBlocks == null) addBlocks = new byte[(volume >> 1) + 1];
+    addBlocks[i >> 1] = (byte) (((i & 1) == 0) ? addBlocks[i >> 1] & 0xF0 | (id >> 8) & 0xF
+            : addBlocks[i >> 1] & 0xF | ((id >> 8) & 0xF) << 4);
+}
+if (allowNeids && id > 4095) {
+    if (addBlocks2 == null) addBlocks2 = new byte[(volume >> 1) + 1];
+    addBlocks2[i >> 1] = (byte) (((i & 1) == 0) ? addBlocks2[i >> 1] & 0xF0 | (id >> 12) & 0xF
+            : addBlocks2[i >> 1] & 0xF | ((id >> 12) & 0xF) << 4);
+}
+```
+
+## Takeaways
+
+* `AddBlocks2` is functionally supported: it is read, and it is written when `allowNeids` is set and an ID exceeds 4095.
+* Conversions that omit the `allowNeids` flag will silently lose the upper nibble of IDs >4095, matching vanilla WorldEdit’s 12-bit ceiling.
+* The nibble packing for `AddBlocks2` matches the reading logic and the classic WorldEdit convention, so round-tripping high IDs is consistent as long as NEIDs output is enabled.

--- a/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
+++ b/src/main/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReader.java
@@ -167,7 +167,6 @@ public class SchematicReader implements ClipboardReader {
 
         byte[] addId = new byte[0];
         byte[] addId2 = new byte[0];
-        short[] blocks = new short[blockId.length]; // Have to later combine IDs
 
         // We support 4096 block IDs using the same method as vanilla Minecraft, where
         // the highest 4 bits are stored in a separate byte array.
@@ -179,28 +178,7 @@ public class SchematicReader implements ClipboardReader {
             addId2 = requireTag(schematic, "AddBlocks2", ByteArrayTag.class).getValue();
         }
 
-        // Combine the AddBlocks data with the first 8-bit block ID
-        for (int index = 0; index < blockId.length; index++) {
-            if ((index >> 1) >= addId.length) { // No corresponding AddBlocks index
-                blocks[index] = (short) (blockId[index] & 0xFF);
-            } else {
-                if ((index & 1) == 0) {
-                    blocks[index] = (short) (((addId[index >> 1] & 0x0F) << 8) + (blockId[index] & 0xFF));
-                } else {
-                    blocks[index] = (short) (((addId[index >> 1] & 0xF0) << 4) + (blockId[index] & 0xFF));
-                }
-            }
-        }
-
-        for (int index = 0; index < blockId.length; index++) {
-            if ((index >> 1) < addId2.length) { // No corresponding AddBlocks2 index
-                if ((index & 1) == 0) {
-                    blocks[index] = (short) (((addId2[index >> 1] & 0x0F) << 8) + (blocks[index] & 0xFFF));
-                } else {
-                    blocks[index] = (short) (((addId2[index >> 1] & 0xF0) << 4) + (blocks[index] & 0xFFF));
-                }
-            }
-        }
+        short[] blocks = combineBlockIds(blockId, addId, addId2);
 
         // Need to pull out tile entities
         List<Tag> tileEntities = requireTag(schematic, "TileEntities", ListTag.class).getValue();
@@ -451,6 +429,38 @@ public class SchematicReader implements ClipboardReader {
         }
 
         return clipboard;
+    }
+
+    static short[] combineBlockIds(byte[] blockId, @Nullable byte[] addId, @Nullable byte[] addId2) {
+        byte[] addIdSafe = addId != null ? addId : new byte[0];
+        byte[] addId2Safe = addId2 != null ? addId2 : new byte[0];
+
+        short[] blocks = new short[blockId.length];
+
+        // Combine the AddBlocks data with the first 8-bit block ID
+        for (int index = 0; index < blockId.length; index++) {
+            if ((index >> 1) >= addIdSafe.length) { // No corresponding AddBlocks index
+                blocks[index] = (short) (blockId[index] & 0xFF);
+            } else {
+                if ((index & 1) == 0) {
+                    blocks[index] = (short) (((addIdSafe[index >> 1] & 0x0F) << 8) + (blockId[index] & 0xFF));
+                } else {
+                    blocks[index] = (short) (((addIdSafe[index >> 1] & 0xF0) << 4) + (blockId[index] & 0xFF));
+                }
+            }
+        }
+
+        for (int index = 0; index < blockId.length; index++) {
+            if ((index >> 1) < addId2Safe.length) { // No corresponding AddBlocks2 index
+                if ((index & 1) == 0) {
+                    blocks[index] = (short) (((addId2Safe[index >> 1] & 0x0F) << 12) + (blocks[index] & 0xFFF));
+                } else {
+                    blocks[index] = (short) (((addId2Safe[index >> 1] & 0xF0) << 8) + (blocks[index] & 0xFFF));
+                }
+            }
+        }
+
+        return blocks;
     }
 
     private static <T extends Tag> T requireTag(Map<String, Tag> items, String key, Class<T> expected)

--- a/src/test/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReaderTest.java
+++ b/src/test/java/com/sk89q/worldedit/extent/clipboard/io/SchematicReaderTest.java
@@ -1,0 +1,37 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.extent.clipboard.io;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class SchematicReaderTest {
+
+    @Test
+    public void readsAddBlocks2HighBits() {
+        short blockId = 15122; // 0x3B12
+
+        byte[] blocks = new byte[] {(byte) (blockId & 0xFF)};
+        byte[] addBlocks = new byte[] {(byte) ((blockId >> 8) & 0x0F)};
+        byte[] addBlocks2 = new byte[] {(byte) ((blockId >> 12) & 0x0F)};
+
+        short[] combined = SchematicReader.combineBlockIds(blocks, addBlocks, addBlocks2);
+
+        assertEquals(blockId, combined[0]);
+    }
+}


### PR DESCRIPTION
## Summary
- fix AddBlocks2 nibble reconstruction so high block ID bits are preserved when reading schematics
- refactor block ID combination into a helper and cover AddBlocks2 handling with a unit test

## Testing
- ./gradlew test --tests com.sk89q.worldedit.extent.clipboard.io.SchematicReaderTest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e95ccef908323827f4ce8eea01ab6)